### PR TITLE
Support not_any for Policy Evaluation Checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ wait_after_review_s: 666
 # * target_ref_name_pattern: A regex pattern that the source branch must match. E.g., 'refs/heads/main'.
 
 # * policy_checks: A list of checks to run for the output of policy evaluations (build checks).
-# Every check in the `evaluation_checks` list must match the same policy evaluation for the entire rule to match.
+# Every check in the `evaluation_checks` list must match the ANY of the policy evaluations for the entire rule to match.
+# The `match_type` property can be set to 'not_any' to change the behavior to require that no single policy evaluation matches the checks in `evaluation_checks`.
 # Note that there can be multiple `evaluation_checks` lists in a rule so that a combination ('AND') of checks can be used to only perform actions based on the output of multiple policy evaluations.
 # See https://learn.microsoft.com/en-us/rest/api/azure/devops/policy/evaluations/list for the API output to understand what JSON Paths are possible.
 # The examples below show how to use the JSON Paths to check the build status.
@@ -267,11 +268,12 @@ rules:
           pattern: '^Work item linking$'
         - json_path: '$.status'
           pattern: '^approved$'
-      - evaluation_checks:
+      - match_type: 'not_any'
+        evaluation_checks:
         - json_path: '$.configuration.type.display_name'
           pattern: '^Required reviewers$'
         - json_path: '$.status'
-          pattern: '^(?:approved|queued)$'
+          pattern: '^(?!approved)'
       - evaluation_checks:
         - json_path: '$.configuration.type.display_name'
           pattern: '^Comment requirements$'

--- a/README.md
+++ b/README.md
@@ -127,11 +127,11 @@ wait_after_review_s: 666
 # * target_ref_name_pattern: A regex pattern that the source branch must match. E.g., 'refs/heads/main'.
 
 # * policy_checks: A list of checks to run for the output of policy evaluations (build checks).
-# Every check in the `evaluation_checks` list must match the ANY of the policy evaluations for the entire rule to match.
-# The `match_type` property can be set to 'not_any' to change the behavior to require that no single policy evaluation matches the checks in `evaluation_checks`.
+# Every check in the `evaluation_checks` list must match at least one of the policy evaluations for the entire rule to match.
+# The `match_type` property can be set to 'not_any' to change the behavior to require that none of the policy evaluation match the checks in `evaluation_checks`.
 # Note that there can be multiple `evaluation_checks` lists in a rule so that a combination ('AND') of checks can be used to only perform actions based on the output of multiple policy evaluations.
 # See https://learn.microsoft.com/en-us/rest/api/azure/devops/policy/evaluations/list for the API output to understand what JSON Paths are possible.
-# The examples below show how to use the JSON Paths to check the build status.
+# The examples below show how to use the JSON Paths and `match_type` to check the build status.
 
 # Checking files:
 # * file_pattern: A regex pattern that a file path must match. A `diff_pattern` is not required when this is set.
@@ -268,6 +268,8 @@ rules:
           pattern: '^Work item linking$'
         - json_path: '$.status'
           pattern: '^approved$'
+      # Make sure that all required approvers have approved by
+      # making sure that none of the checks for required reviewers are not approved.
       - match_type: 'not_any'
         evaluation_checks:
         - json_path: '$.configuration.type.display_name'

--- a/src/config.py
+++ b/src/config.py
@@ -4,7 +4,6 @@ from typing import Optional, TypedDict
 
 from jsonpath import JSONPath
 
-
 DEFAULT_MAX_REQUEUES_PER_RUN = 10
 
 
@@ -17,8 +16,19 @@ class RequeueConfig(TypedDict):
 
 
 class MatchType(Enum):
+	"""
+	How the checks combination of the checks should be evaluated.
+	"""
+
 	ANY = "any"
+	"""
+	At least one of the checks should match.
+	"""
+
 	NOT_ANY = "not_any"
+	"""
+	None of the checks should match.
+	"""
 
 
 class JsonPathCheck(TypedDict):
@@ -33,6 +43,9 @@ class JsonPathCheck(TypedDict):
 
 class PolicyEvaluationChecks(TypedDict):
 	match_type: MatchType
+	"""
+	Determines how the checks combination of the checks should be evaluated.
+	"""
 	evaluation_checks: list[JsonPathCheck]
 
 
@@ -96,6 +109,7 @@ class Config(TypedDict):
 	project: str
 	repository_name: str
 	top: int
+
 	requeue_config: Optional[RequeueConfig]
 
 	rules: list[Rule]

--- a/src/config.py
+++ b/src/config.py
@@ -1,7 +1,15 @@
 import re
-from typing import Collection, Optional, TypedDict
+from typing import Optional, TypedDict
 
 from jsonpath import JSONPath
+
+
+from enum import Enum
+
+
+class MatchType(Enum):
+	ANY = "any"
+	NOT_ANY = "not_any"
 
 
 class JsonPathCheck(TypedDict):
@@ -15,6 +23,7 @@ class JsonPathCheck(TypedDict):
 
 
 class PolicyEvaluationChecks(TypedDict):
+	match_type: MatchType
 	evaluation_checks: list[JsonPathCheck]
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -9,6 +9,7 @@ from jsonpath import JSONPath
 class RequeueConfig(TypedDict):
 	max_per_run: Optional[int]
 
+
 class MatchType(Enum):
 	ANY = "any"
 	NOT_ANY = "not_any"

--- a/src/config.py
+++ b/src/config.py
@@ -1,13 +1,19 @@
-
-from enum import Enum
 import re
+from enum import Enum
 from typing import Optional, TypedDict
 
 from jsonpath import JSONPath
 
 
+DEFAULT_MAX_REQUEUES_PER_RUN = 10
+
+
 class RequeueConfig(TypedDict):
 	max_per_run: Optional[int]
+	"""
+	The maximum number of re-queues to perform in a single run across all rules for all pull requests.
+	Defaults to 10.
+	"""
 
 
 class MatchType(Enum):
@@ -90,6 +96,8 @@ class Config(TypedDict):
 	project: str
 	repository_name: str
 	top: int
+	requeue_config: Optional[RequeueConfig]
+
 	rules: list[Rule]
 	unique_path_regexs: set[re.Pattern]
 
@@ -98,5 +106,3 @@ class Config(TypedDict):
 	user_id: Optional[str]
 
 	is_stats_enabled: Optional[bool]
-
-	requeue_config: Optional[RequeueConfig]

--- a/src/config.py
+++ b/src/config.py
@@ -1,11 +1,13 @@
+
+from enum import Enum
 import re
 from typing import Optional, TypedDict
 
 from jsonpath import JSONPath
 
 
-from enum import Enum
-
+class RequeueConfig(TypedDict):
+	max_per_run: Optional[int]
 
 class MatchType(Enum):
 	ANY = "any"
@@ -95,3 +97,5 @@ class Config(TypedDict):
 	user_id: Optional[str]
 
 	is_stats_enabled: Optional[bool]
+
+	requeue_config: Optional[RequeueConfig]

--- a/src/run.py
+++ b/src/run.py
@@ -1,5 +1,6 @@
 import datetime
 import hashlib
+import json
 import logging
 import os
 import pathlib
@@ -492,8 +493,8 @@ class Runner:
 		if policy_evaluations is None:
 			policy_evaluations_: list[PolicyEvaluationRecord] = self.policy_client.get_policy_evaluations(project, f'vstfs:///CodeReview/CodeReviewId/{project_id}/{pr.pull_request_id}')
 			policy_evaluations = [c.as_dict() for c in policy_evaluations_]
-			self.logger.debug("Policy evaluations: %s\nfor %s", policy_evaluations, pr_url)
-			# import json; self.logger.debug("Policy evaluations: %s\nfor %s", json.dumps(policy_evaluations, indent=2), pr_url)
+			if self.logger.isEnabledFor(logging.DEBUG):
+				self.logger.debug("Policy evaluations: %s\nfor %s", json.dumps(policy_evaluations, indent=2), pr_url)
 		all_rules_match = all(self.is_rule_match_policy_evals(r, policy_evaluations) for r in rule_policy_checks)
 		return all_rules_match, policy_evaluations
 

--- a/src/run.py
+++ b/src/run.py
@@ -82,14 +82,13 @@ class Runner:
 				break
 
 	def log_docker_image_build_timestamp(self) -> None:
-		docker_image_build_timestamp = None
 		this_dir = os.path.dirname(__file__)
 		timestamp_file_path = os.path.join(this_dir, '.docker_image_build_timestamp')
 		if pathlib.Path(timestamp_file_path).exists():
 			with open(timestamp_file_path, 'r') as f:
 				docker_image_build_timestamp = f.read().strip()
-		self.logger.info(f"Current time: {datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S')}"
-				f" | Docker Image Build Date: {docker_image_build_timestamp}")
+				self.logger.info(f"Current time: {datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S')}"
+						f" | Docker Image Build Date: {docker_image_build_timestamp}")
 
 	def load_config(self) -> None:
 		config_contents = None
@@ -616,6 +615,8 @@ class Runner:
 					else:
 						self.logger.debug("Skipping diff for \"%s\" for \"%s\".", change_type, modified_path)
 				except:
+					# This usually happens when the file doesn't exist anymore in the target branch.
+					# Pulling the target branch should help.
 					self.logger.exception("Failed to get diff for \"%s\" for \"%s\".\n  Title: \"%s\"\n  URL: %s", change_type, modified_path, pr.title, pr_url)
 
 		return result

--- a/src/run.py
+++ b/src/run.py
@@ -766,7 +766,7 @@ class Runner:
 	def requeue_policy(self, pr: GitPullRequest, pr_url: str, project: str, is_dry_run: bool, policy_evaluations: list[dict], threads: Optional[list[GitPullRequestCommentThread]], requeue: list[JsonPathCheck], requeue_comment: Optional[str], comment_id: Optional[str], state: RunState):
 		requeue_config = self.config['requeue_config']
 		assert requeue_config is not None
-		max_requeues_per_run = requeue_config.get('max_per_run')
+		max_requeues_per_run = requeue_config['max_per_run']
 		assert max_requeues_per_run is not None
 		# Find the policy to requeue.
 		for policy_evaluation in policy_evaluations:

--- a/src/run_state.py
+++ b/src/run_state.py
@@ -1,0 +1,2 @@
+class RunState:
+	num_requeues: int

--- a/src/run_state.py
+++ b/src/run_state.py
@@ -1,2 +1,5 @@
 class RunState:
-	num_requeues: int
+	num_requeues: int = 0
+	"""
+	The number of re-queues that have been performed so far in this run across all rules for all pull requests.
+	"""

--- a/src/run_state.py
+++ b/src/run_state.py
@@ -1,4 +1,9 @@
 class RunState:
+	"""
+	Represents the state of the current iteration that goes through all rules for all pull requests.
+	Resets after going through all pull requests.
+	"""
+
 	num_requeues: int = 0
 	"""
 	The number of re-queues that have been performed so far in this run across all rules for all pull requests.


### PR DESCRIPTION
This will help with requeue when checking the policies for required reviewers.

Also:
* Support max num requeues per run. 
* Pretty print debugging logging for policy checks.
* Don't show Docker image build time when the file doesn't exist (because it's kind of confusing to see it for you don't care about the Docker stuff, but I get that it was nice to have originally for debugging)
