### PR TITLE
Add option to reset the vote if no rule votes

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ wait_after_review_s: 666
 # Defaults to false.
 # is_dry_run: true
 
+# Optional: Reset the vote if none of the rules in this config file cast a vote during the current run.
+# This is especially useful when running the Code Reviewer as an independent bot with its own user account (rather than running it on behalf of a human user).
+# It allows resetting the vote in cases where an issue that was detected by a rule has been corrected without changing the code, for example by changing the PR description.
+# A rule is considered to have cast a vote if its checks match and it has a 'vote' action and its vote would have been applied to the PR if the vote on the PR had been reset first.
+# So, even if the rule's 'vote' action would set the vote to the same value it's already set to or to a less rejective value, the rule still counts as having voted, meaning that it will prevent the vote from being reset.
+# (Also see the docs for voting below.)
+# reset_votes_if_no_rule_votes:
+#   - APPROVE
+#   - APPROVE_WITH_SUGGESTIONS
+#   - WAIT
+#   - REJECT
+
 # All checks within each rule must match for the rule to be applied.
 
 # Rules can have:

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -190,6 +190,7 @@ class Config(TypedDict):
     wait_after_review_s: Optional[int]
 
     reset_votes_after_changes: Optional[Collection[int]]
+    reset_votes_if_no_rule_votes: Optional[Collection[int]]
 
     rules: list[Rule]
 

--- a/src/config/loader.py
+++ b/src/config/loader.py
@@ -73,14 +73,8 @@ class ConfigLoader:
                 if requeue_config.get('max_per_run') is None:
                     requeue_config['max_per_run'] = DEFAULT_MAX_REQUEUES_PER_RUN
 
-            reset_votes_after_changes = config.get('reset_votes_after_changes')
-            if reset_votes_after_changes is not None:
-                assert isinstance(
-                    reset_votes_after_changes, list), f"reset_votes_after_changes must be a list. Got: {reset_votes_after_changes} with type: {type(reset_votes_after_changes)}"
-                reset_votes_after_changes = set(map_vote(vote) for vote in reset_votes_after_changes)
-                assert all(
-                    vote is not None for vote in reset_votes_after_changes), f"reset_votes_after_changes must be a list of integers. Got: {reset_votes_after_changes}"
-                config['reset_votes_after_changes'] = reset_votes_after_changes  # type: ignore
+            self._load_vote_list(config, 'reset_votes_after_changes')
+            self._load_vote_list(config, 'reset_votes_if_no_rule_votes')
 
             rules = config['rules']
             for rule in rules:
@@ -124,6 +118,16 @@ class ConfigLoader:
 
             self.logger.info("Loaded configuration with %d rule(s).", len(rules))
         return ConfigLoadInfo(self.config, is_fresh)
+
+    def _load_vote_list(self, config, field_name):
+        vote_list = config.get(field_name)
+        if vote_list is not None:
+            assert isinstance(
+                vote_list, list), f"{field_name} must be a list. Got: {vote_list} with type: {type(vote_list)}"
+            vote_list = set(map_vote(vote) for vote in vote_list)
+            assert all(
+                vote is not None for vote in vote_list), f"{field_name} must be a list of integers. Got: {vote_list}"
+            config[field_name] = vote_list  # type: ignore
 
     @staticmethod
     def init_matchers(matchers: list[JsonPathChecks]) -> None:

--- a/src/run.py
+++ b/src/run.py
@@ -370,12 +370,12 @@ class Runner:
                     vote_str = map_int_vote(vote)
                     if not is_dry_run:
                         self.logger.info("SETTING VOTE: '%s'\nTitle: \"%s\"\nBy %s (%s)\n%s", vote_str,
-                                        pr.title, pr_author.display_name, pr_author.unique_name, pr_url)
+                                         pr.title, pr_author.display_name, pr_author.unique_name, pr_url)
                         self.git_client.create_pull_request_reviewer(
                             reviewer, repository_id, pr.pull_request_id, reviewer_id=user_id, project=project)
                     else:
                         self.logger.info("Would vote: '%s'\nTitle: \"%s\"\nBy %s (%s)\n%s", vote_str,
-                                        pr.title, pr_author.display_name, pr_author.unique_name, pr_url)
+                                         pr.title, pr_author.display_name, pr_author.unique_name, pr_url)
 
         reset_votes_if_no_rule_votes = self.config.get('reset_votes_if_no_rule_votes')
         if (not has_any_rule_voted
@@ -385,7 +385,8 @@ class Runner:
             reviewer.vote = NO_VOTE
             if not is_dry_run:
                 self.logger.info("RESETTING VOTE because no rule voted on: \"%s\"\n  URL: %s", pr.title, pr_url)
-                self.git_client.create_pull_request_reviewer(reviewer, repository_id, pr.pull_request_id, reviewer_id=user_id, project=project)
+                self.git_client.create_pull_request_reviewer(
+                    reviewer, repository_id, pr.pull_request_id, reviewer_id=user_id, project=project)
             else:
                 self.logger.info("Would reset vote because no rule voted on: \"%s\"\n  URL: %s", pr.title, pr_url)
 

--- a/src/voting.py
+++ b/src/voting.py
@@ -56,11 +56,15 @@ def map_int_vote(vote: int) -> str | None:
 
 def is_vote_allowed(current_vote: int | None, new_vote: int | None) -> bool:
     """
-    Only vote if the new vote is more rejective (more negative) than the current vote,
+    Only vote if the new vote is more rejective (more negative) than the current vote or if
     the current vote is not set and the new vote is approve or approve with suggestions.
-    This is to avoid approving if someone has already voted.
+    This is to avoid approving if someone using the same user account has already voted.
     """
     return new_vote is not None \
         and (current_vote is None
              or new_vote < current_vote
              or (current_vote == NO_VOTE and new_vote > current_vote))
+
+
+def is_vote_set(vote: int | None) -> bool:
+    return vote is not None and vote != NO_VOTE

--- a/src/voting.py
+++ b/src/voting.py
@@ -4,6 +4,7 @@ import logging
 APPROVE_VOTE = 10
 APPROVE_WITH_SUGGESTIONS_VOTE = 5
 NO_VOTE = 0
+WAIT = -5
 
 
 def map_vote(vote: Optional[int | str]) -> Optional[int]:
@@ -15,7 +16,7 @@ def map_vote(vote: Optional[int | str]) -> Optional[int]:
         case 'reject':
             return -10
         case 'wait':
-            return -5
+            return WAIT
         case 'none' | 'reset':
             return NO_VOTE
         case 'approve_with_suggestions':

--- a/src/voting.py
+++ b/src/voting.py
@@ -5,6 +5,7 @@ APPROVE_VOTE = 10
 APPROVE_WITH_SUGGESTIONS_VOTE = 5
 NO_VOTE = 0
 WAIT_VOTE = -5
+REJECT_VOTE = -10
 
 
 def map_vote(vote: Optional[int | str]) -> Optional[int]:
@@ -14,7 +15,7 @@ def map_vote(vote: Optional[int | str]) -> Optional[int]:
         f"`vote` must be a string. Got: \"{vote}\" with type: {type(vote)}."
     match vote.lower():
         case 'reject':
-            return -10
+            return REJECT_VOTE
         case 'wait':
             return WAIT_VOTE
         case 'none' | 'reset':

--- a/src/voting.py
+++ b/src/voting.py
@@ -4,7 +4,7 @@ import logging
 APPROVE_VOTE = 10
 APPROVE_WITH_SUGGESTIONS_VOTE = 5
 NO_VOTE = 0
-WAIT = -5
+WAIT_VOTE = -5
 
 
 def map_vote(vote: Optional[int | str]) -> Optional[int]:
@@ -16,7 +16,7 @@ def map_vote(vote: Optional[int | str]) -> Optional[int]:
         case 'reject':
             return -10
         case 'wait':
-            return WAIT
+            return WAIT_VOTE
         case 'none' | 'reset':
             return NO_VOTE
         case 'approve_with_suggestions':

--- a/tests/configs/both_reset_votes_options.yml
+++ b/tests/configs/both_reset_votes_options.yml
@@ -1,0 +1,31 @@
+organization_url: 'https://example.com/azure-devops'
+project: ExampleProject
+repository_name: ExampleRepo
+
+user_id: 'code_reviewer_user_id'
+
+log_level: DEBUG
+
+reset_votes_after_changes:
+  - APPROVE
+  - APPROVE_WITH_SUGGESTIONS
+  - WAIT
+  - REJECT
+
+reset_votes_if_no_rule_votes:
+  - APPROVE
+  - APPROVE_WITH_SUGGESTIONS
+  - WAIT
+  - REJECT
+
+rules:
+  - vote: wait
+    path_pattern: '.*\.py$'
+    diff_pattern: '.*?\.deprecated_method\(\)'
+    comment: 'Please do not use the deprecated method `deprecated_method`. Use `new_method` instead.'
+    comment_id: 'deprecated-method'
+
+  - vote: wait
+    description_pattern: '.*?\bforbidden phrase\b'
+    comment: 'Please do not use the forbidden phrase in the description.'
+    comment_id: 'description-forbidden-phrase'

--- a/tests/configs/no_rules_reset_votes_after_changes.yml
+++ b/tests/configs/no_rules_reset_votes_after_changes.yml
@@ -1,0 +1,15 @@
+organization_url: 'https://example.com/azure-devops'
+project: ExampleProject
+repository_name: ExampleRepo
+
+user_id: 'code_reviewer_user_id'
+
+log_level: DEBUG
+
+reset_votes_after_changes:
+  - APPROVE
+  - APPROVE_WITH_SUGGESTIONS
+  - WAIT
+  - REJECT
+
+rules: []

--- a/tests/configs/rule_based_on_vote_no_reset.yml
+++ b/tests/configs/rule_based_on_vote_no_reset.yml
@@ -1,0 +1,15 @@
+organization_url: 'https://example.com/azure-devops'
+project: ExampleProject
+repository_name: ExampleRepo
+
+user_id: 'code_reviewer_user_id'
+
+log_level: DEBUG
+
+rules:
+  - matchers:
+      - checks:
+          - json_path: '$.reviewers[*].vote'
+            pattern: '^-5$'
+    add_tags:
+      - 'wait'

--- a/tests/configs/rule_based_on_vote_then_reset.yml
+++ b/tests/configs/rule_based_on_vote_then_reset.yml
@@ -1,0 +1,21 @@
+organization_url: 'https://example.com/azure-devops'
+project: ExampleProject
+repository_name: ExampleRepo
+
+user_id: 'code_reviewer_user_id'
+
+log_level: DEBUG
+
+reset_votes_if_no_rule_votes:
+  - APPROVE
+  - APPROVE_WITH_SUGGESTIONS
+  - WAIT
+  - REJECT
+
+rules:
+  - matchers:
+      - checks:
+          - json_path: '$.reviewers[*].vote'
+            pattern: '^-5$'
+    add_tags:
+      - 'wait'

--- a/tests/configs/vote_approve.yml
+++ b/tests/configs/vote_approve.yml
@@ -1,0 +1,17 @@
+organization_url: 'https://example.com/azure-devops'
+project: ExampleProject
+repository_name: ExampleRepo
+
+user_id: 'code_reviewer_user_id'
+
+log_level: DEBUG
+
+reset_votes_if_no_rule_votes:
+  - APPROVE
+  - APPROVE_WITH_SUGGESTIONS
+  - WAIT
+  - REJECT
+
+rules:
+  - vote: approve
+    title_pattern: '^Auto-format code$'

--- a/tests/configs/vote_based_on_description.yml
+++ b/tests/configs/vote_based_on_description.yml
@@ -14,6 +14,6 @@ reset_votes_if_no_rule_votes:
 
 rules:
   - vote: wait
-    description_pattern: 'forbidden phrase'
+    description_pattern: '.*?\bforbidden phrase\b'
     comment: 'Please do not use the forbidden phrase in the description.'
     comment_id: 'description-forbidden-phrase'

--- a/tests/configs/vote_based_on_description.yml
+++ b/tests/configs/vote_based_on_description.yml
@@ -1,0 +1,19 @@
+organization_url: 'https://example.com/azure-devops'
+project: ExampleProject
+repository_name: ExampleRepo
+
+user_id: 'code_reviewer_user_id'
+
+log_level: DEBUG
+
+reset_votes_after_changes:
+  - APPROVE
+  - APPROVE_WITH_SUGGESTIONS
+  - WAIT
+  - REJECT
+
+rules:
+  - vote: wait
+    description_pattern: "forbidden phrase"
+    comment: "Please do not use the forbidden phrase in the description."
+    comment_id: "description-forbidden-phrase"

--- a/tests/configs/vote_based_on_description.yml
+++ b/tests/configs/vote_based_on_description.yml
@@ -6,7 +6,7 @@ user_id: 'code_reviewer_user_id'
 
 log_level: DEBUG
 
-reset_votes_after_changes:
+reset_votes_if_no_rule_votes:
   - APPROVE
   - APPROVE_WITH_SUGGESTIONS
   - WAIT

--- a/tests/configs/vote_based_on_diff_pattern.yml
+++ b/tests/configs/vote_based_on_diff_pattern.yml
@@ -14,7 +14,7 @@ reset_votes_after_changes:
 
 rules:
   - vote: wait
-    path_pattern: '\.py$'
-    diff_pattern: '\.deprecated_method\(\)'
+    path_pattern: '.*\.py$'
+    diff_pattern: '.*?\.deprecated_method\(\)'
     comment: 'Please do not use the deprecated method `deprecated_method`. Use `new_method` instead.'
     comment_id: 'deprecated-method'

--- a/tests/configs/vote_based_on_diff_pattern.yml
+++ b/tests/configs/vote_based_on_diff_pattern.yml
@@ -14,6 +14,7 @@ reset_votes_after_changes:
 
 rules:
   - vote: wait
-    description_pattern: 'forbidden phrase'
-    comment: 'Please do not use the forbidden phrase in the description.'
-    comment_id: 'description-forbidden-phrase'
+    path_pattern: '\.py$'
+    diff_pattern: '\.deprecated_method\(\)'
+    comment: 'Please do not use the deprecated method `deprecated_method`. Use `new_method` instead.'
+    comment_id: 'deprecated-method'

--- a/tests/configs/vote_based_on_diff_pattern_new.yml
+++ b/tests/configs/vote_based_on_diff_pattern_new.yml
@@ -1,0 +1,20 @@
+organization_url: 'https://example.com/azure-devops'
+project: ExampleProject
+repository_name: ExampleRepo
+
+user_id: 'code_reviewer_user_id'
+
+log_level: DEBUG
+
+reset_votes_if_no_rule_votes:
+  - APPROVE
+  - APPROVE_WITH_SUGGESTIONS
+  - WAIT
+  - REJECT
+
+rules:
+  - vote: wait
+    path_pattern: '.*\.py$'
+    diff_pattern: '.*?\.deprecated_method\(\)'
+    comment: 'Please do not use the deprecated method `deprecated_method`. Use `new_method` instead.'
+    comment_id: 'deprecated-method'

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -458,7 +458,7 @@ def test_review_pr_rule_based_on_vote_then_reset():
     runner.git_client.create_pull_request_label.return_value = WebApiTagDefinition(name="wait")
 
     # The PR ID should be unique across test cases.
-    pr_id = 160160
+    pr_id = 170170
     pr = GitPullRequest(
         created_by=IdentityRef(display_name="P.R. Author"),
         is_draft=False,
@@ -488,3 +488,309 @@ def test_review_pr_rule_based_on_vote_then_reset():
     assert call_args.args[0].vote == NO_VOTE
     assert call_args.args[2] == pr_id
     assert call_args.kwargs.get("reviewer_id") == runner.config["user_id"]
+
+
+@mock.patch.object(requests, "get")
+def test_review_pr_both_reset_votes_options_both_reset(mock_requests_get):
+    """
+    This tests the scenario where both reset_votes_after_changes and reset_votes_if_no_rule_votes are used in the same
+    config file and both should trigger a reset of the vote. This tests esp. that the vote isn't attempted to be reset
+    twice.
+    """
+    config_path = os.path.join(TESTS_DIR, "configs/both_reset_votes_options.yml")
+    inj = Injector([
+        ConfigModule(config_path),
+        LoggingModule,
+    ])
+    runner = inj.get(Runner)
+    reload_info = runner.config_loader.load_config()
+    runner.config = reload_info.config
+    runner.rest_api_kwargs = {}
+    runner.git_client = mock.MagicMock()
+    runner.git_client.get_threads.return_value = [
+        GitPullRequestCommentThread(
+            comments=[Comment(author=IdentityRef(id=runner.config["user_id"]))],
+            last_updated_date=datetime(2024, 12, 19),
+            properties={"CodeReviewVoteResult": {"$value": WAIT_VOTE}},
+        ),
+    ]
+    runner.git_client.get_pull_request_iterations.return_value = [
+        GitPullRequestIteration(updated_date=datetime(2024, 12, 18)),
+        GitPullRequestIteration(updated_date=datetime(2024, 12, 20)),
+    ]
+    runner.git_client.get_commit_diffs.return_value = GitCommitDiffs(
+        changes=[{
+            "changeType": "edit",
+            "item": {
+                "isFolder": False,
+                "path": "foo.py",
+            },
+        }],
+    )
+    diff = Diff(blocks=[Block(
+        changeType=1,
+        mLines=["    bar = foo.new_method()"],
+        mLine=5,
+        mLinesCount=1,
+    )])
+    mock_diff_response = mock.MagicMock()
+    mock_diff_response.json.return_value = diff
+    mock_requests_get.return_value = mock_diff_response
+
+    # The PR ID should be unique across test cases.
+    pr_id = 180180
+    pr = GitPullRequest(
+        created_by=IdentityRef(display_name="P.R. Author"),
+        description="This is a good description.",
+        is_draft=False,
+        # Reusing the PR ID as the commit ID to ensure unique commit IDs across test cases.
+        last_merge_source_commit=GitCommitRef(commit_id=str(pr_id)),
+        pull_request_id=pr_id,
+        repository=GitRepository(),
+        reviewers=[
+            IdentityRefWithVote(id=runner.config["user_id"], vote=WAIT_VOTE),
+        ],
+        source_ref_name=f"branch{pr_id}",
+        status="active",
+        target_ref_name="master",
+    )
+    pr_url = f"https://example.com/pr/{pr_id}"
+
+    runner.review_pr(pr, pr_url, run_state=None)
+
+    runner.git_client.create_pull_request_reviewer.assert_called_once()
+    call_args = runner.git_client.create_pull_request_reviewer.call_args
+    assert call_args.args[0].id == runner.config["user_id"]
+    assert call_args.args[0].vote == NO_VOTE
+    assert call_args.args[2] == pr_id
+    assert call_args.kwargs.get("reviewer_id") == runner.config["user_id"]
+
+
+@mock.patch.object(requests, "get")
+def test_review_pr_both_reset_votes_options_reset_after_changes(mock_requests_get):
+    """
+    This tests the scenario where both reset_votes_after_changes and reset_votes_if_no_rule_votes are used in the same
+    config file and only reset_votes_after_changes should trigger a reset.
+    """
+    config_path = os.path.join(TESTS_DIR, "configs/both_reset_votes_options.yml")
+    inj = Injector([
+        ConfigModule(config_path),
+        LoggingModule,
+    ])
+    runner = inj.get(Runner)
+    reload_info = runner.config_loader.load_config()
+    runner.config = reload_info.config
+    runner.rest_api_kwargs = {}
+    runner.git_client = mock.MagicMock()
+    runner.git_client.get_threads.return_value = [
+        GitPullRequestCommentThread(
+            comments=[Comment(author=IdentityRef(id=runner.config["user_id"]))],
+            last_updated_date=datetime(2024, 12, 19),
+            properties={"CodeReviewVoteResult": {"$value": WAIT_VOTE}},
+        ),
+    ]
+    runner.git_client.get_pull_request_iterations.return_value = [
+        GitPullRequestIteration(updated_date=datetime(2024, 12, 18)),
+        GitPullRequestIteration(updated_date=datetime(2024, 12, 20)),
+    ]
+    runner.git_client.get_commit_diffs.return_value = GitCommitDiffs(
+        changes=[{
+            "changeType": "edit",
+            "item": {
+                "isFolder": False,
+                "path": "foo.py",
+            },
+        }],
+    )
+    diff = Diff(blocks=[Block(
+        changeType=1,
+        mLines=["    bar = foo.new_method()"],
+        mLine=5,
+        mLinesCount=1,
+    )])
+    mock_diff_response = mock.MagicMock()
+    mock_diff_response.json.return_value = diff
+    mock_requests_get.return_value = mock_diff_response
+
+    # Use a side_effect to collect the votes in the call args for create_pull_request_reviewer because we reuse the
+    # same reviewer object that is passed to the first call and we change the vote value later.
+    call_arg_votes = []
+    def mock_create_pull_request_reviewer(*args, **kwargs):
+        call_arg_votes.append(args[0].vote)
+    runner.git_client.create_pull_request_reviewer.side_effect = mock_create_pull_request_reviewer
+
+    # The PR ID should be unique across test cases.
+    pr_id = 190190
+    pr = GitPullRequest(
+        created_by=IdentityRef(display_name="P.R. Author"),
+        description="This is a bad description containing the forbidden phrase.",
+        is_draft=False,
+        # Reusing the PR ID as the commit ID to ensure unique commit IDs across test cases.
+        last_merge_source_commit=GitCommitRef(commit_id=str(pr_id)),
+        pull_request_id=pr_id,
+        repository=GitRepository(),
+        reviewers=[
+            IdentityRefWithVote(id=runner.config["user_id"], vote=WAIT_VOTE),
+        ],
+        source_ref_name=f"branch{pr_id}",
+        status="active",
+        target_ref_name="master",
+    )
+    pr_url = f"https://example.com/pr/{pr_id}"
+
+    runner.review_pr(pr, pr_url, run_state=None)
+
+    runner.git_client.create_pull_request_reviewer.call_count == len(call_arg_votes) == 2
+    call_args_list = runner.git_client.create_pull_request_reviewer.call_args_list
+    assert call_args_list[0].args[0].id == runner.config["user_id"]
+    assert call_arg_votes[0] == NO_VOTE
+    assert call_args_list[0].args[2] == pr_id
+    assert call_args_list[0].kwargs.get("reviewer_id") == runner.config["user_id"]
+    assert call_args_list[1].args[0].id == runner.config["user_id"]
+    assert call_arg_votes[1] == WAIT_VOTE
+    assert call_args_list[1].args[2] == pr_id
+    assert call_args_list[1].kwargs.get("reviewer_id") == runner.config["user_id"]
+
+
+@mock.patch.object(requests, "get")
+def test_review_pr_both_reset_votes_options_reset_no_rule_voted(mock_requests_get):
+    """
+    This tests the scenario where both reset_votes_after_changes and reset_votes_if_no_rule_votes are used in the same
+    config file and only reset_votes_if_no_rule_votes should trigger a reset.
+    """
+    config_path = os.path.join(TESTS_DIR, "configs/both_reset_votes_options.yml")
+    inj = Injector([
+        ConfigModule(config_path),
+        LoggingModule,
+    ])
+    runner = inj.get(Runner)
+    reload_info = runner.config_loader.load_config()
+    runner.config = reload_info.config
+    runner.rest_api_kwargs = {}
+    runner.git_client = mock.MagicMock()
+    runner.git_client.get_threads.return_value = [
+        GitPullRequestCommentThread(
+            comments=[Comment(author=IdentityRef(id=runner.config["user_id"]))],
+            last_updated_date=datetime(2024, 12, 19),
+            properties={"CodeReviewVoteResult": {"$value": WAIT_VOTE}},
+        ),
+    ]
+    runner.git_client.get_pull_request_iterations.return_value = [
+        GitPullRequestIteration(updated_date=datetime(2024, 12, 18)),
+    ]
+    runner.git_client.get_commit_diffs.return_value = GitCommitDiffs(
+        changes=[{
+            "changeType": "edit",
+            "item": {
+                "isFolder": False,
+                "path": "foo.py",
+            },
+        }],
+    )
+    diff = Diff(blocks=[Block(
+        changeType=1,
+        mLines=["    bar = foo.new_method()"],
+        mLine=5,
+        mLinesCount=1,
+    )])
+    mock_diff_response = mock.MagicMock()
+    mock_diff_response.json.return_value = diff
+    mock_requests_get.return_value = mock_diff_response
+
+    # The PR ID should be unique across test cases.
+    pr_id = 200200
+    pr = GitPullRequest(
+        created_by=IdentityRef(display_name="P.R. Author"),
+        description="This is a good description.",
+        is_draft=False,
+        # Reusing the PR ID as the commit ID to ensure unique commit IDs across test cases.
+        last_merge_source_commit=GitCommitRef(commit_id=str(pr_id)),
+        pull_request_id=pr_id,
+        repository=GitRepository(),
+        reviewers=[
+            IdentityRefWithVote(id=runner.config["user_id"], vote=WAIT_VOTE),
+        ],
+        source_ref_name=f"branch{pr_id}",
+        status="active",
+        target_ref_name="master",
+    )
+    pr_url = f"https://example.com/pr/{pr_id}"
+
+    runner.review_pr(pr, pr_url, run_state=None)
+
+    runner.git_client.create_pull_request_reviewer.assert_called_once()
+    call_args = runner.git_client.create_pull_request_reviewer.call_args
+    assert call_args.args[0].id == runner.config["user_id"]
+    assert call_args.args[0].vote == NO_VOTE
+    assert call_args.args[2] == pr_id
+    assert call_args.kwargs.get("reviewer_id") == runner.config["user_id"]
+
+
+@mock.patch.object(requests, "get")
+def test_review_pr_both_reset_votes_options_no_reset(mock_requests_get):
+    """
+    This tests the scenario where both reset_votes_after_changes and reset_votes_if_no_rule_votes are used in the same
+    config file and neither should trigger a reset. This also tests that a rule that sets the vote to the same
+    (non-NO_VOTE) value that it's already set to is recognized by reset_votes_if_no_rule_votes as having voted.
+    """
+    config_path = os.path.join(TESTS_DIR, "configs/both_reset_votes_options.yml")
+    inj = Injector([
+        ConfigModule(config_path),
+        LoggingModule,
+    ])
+    runner = inj.get(Runner)
+    reload_info = runner.config_loader.load_config()
+    runner.config = reload_info.config
+    runner.rest_api_kwargs = {}
+    runner.git_client = mock.MagicMock()
+    runner.git_client.get_threads.return_value = [
+        GitPullRequestCommentThread(
+            comments=[Comment(author=IdentityRef(id=runner.config["user_id"]))],
+            last_updated_date=datetime(2024, 12, 19),
+            properties={"CodeReviewVoteResult": {"$value": WAIT_VOTE}},
+        ),
+    ]
+    runner.git_client.get_pull_request_iterations.return_value = [
+        GitPullRequestIteration(updated_date=datetime(2024, 12, 18)),
+    ]
+    runner.git_client.get_commit_diffs.return_value = GitCommitDiffs(
+        changes=[{
+            "changeType": "edit",
+            "item": {
+                "isFolder": False,
+                "path": "foo.py",
+            },
+        }],
+    )
+    diff = Diff(blocks=[Block(
+        changeType=1,
+        mLines=["    bar = foo.deprecated_method()"],
+        mLine=5,
+        mLinesCount=1,
+    )])
+    mock_diff_response = mock.MagicMock()
+    mock_diff_response.json.return_value = diff
+    mock_requests_get.return_value = mock_diff_response
+
+    # The PR ID should be unique across test cases.
+    pr_id = 210210
+    pr = GitPullRequest(
+        created_by=IdentityRef(display_name="P.R. Author"),
+        description="This is a bad description containing the forbidden phrase.",
+        is_draft=False,
+        # Reusing the PR ID as the commit ID to ensure unique commit IDs across test cases.
+        last_merge_source_commit=GitCommitRef(commit_id=str(pr_id)),
+        pull_request_id=pr_id,
+        repository=GitRepository(),
+        reviewers=[
+            IdentityRefWithVote(id=runner.config["user_id"], vote=WAIT_VOTE),
+        ],
+        source_ref_name=f"branch{pr_id}",
+        status="active",
+        target_ref_name="master",
+    )
+    pr_url = f"https://example.com/pr/{pr_id}"
+
+    runner.review_pr(pr, pr_url, run_state=None)
+
+    runner.git_client.create_pull_request_reviewer.assert_not_called()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from azure.devops.released.git import (
     Comment,
+    GitCommitDiffs,
     GitPullRequest,
     GitPullRequestCommentThread,
     GitPullRequestIteration,
@@ -12,14 +13,84 @@ from azure.devops.released.git import (
     IdentityRefWithVote,
 )
 from injector import Injector
+import requests
 
 from config.config_module import ConfigModule
+from file_diff import Block, Diff
 from logger import LoggingModule
 from run import Runner
 from voting import NO_VOTE, WAIT
 
 
 TESTS_DIR = os.path.dirname(__file__)
+
+
+@mock.patch.object(requests, "get")
+def test_review_pr_vote_based_on_diff_pattern_reset(mock_requests_get):
+    """
+    This tests the scenario where there's a rule that votes based on a diff pattern and the vote has already been
+    applied to the PR and a new iteration was pushed and now the vote needs to be reset.
+    """
+    config_path = os.path.join(TESTS_DIR, "configs/vote_based_on_diff_pattern.yml")
+    inj = Injector([
+        ConfigModule(config_path),
+        LoggingModule,
+    ])
+    runner = inj.get(Runner)
+    reload_info = runner.config_loader.load_config()
+    runner.config = reload_info.config
+    runner.git_client = mock.MagicMock()
+    runner.git_client.get_threads.return_value = [
+        GitPullRequestCommentThread(
+            comments=[Comment(author=IdentityRef(id=runner.config["user_id"]))],
+            last_updated_date=datetime(2024, 12, 19),
+            properties={"CodeReviewVoteResult": {"$value": WAIT}},
+        ),
+    ]
+    runner.git_client.get_pull_request_iterations.return_value = [
+        GitPullRequestIteration(updated_date=datetime(2024, 12, 18)),
+        GitPullRequestIteration(updated_date=datetime(2024, 12, 20)),
+    ]
+    runner.git_client.get_commit_diffs.return_value = GitCommitDiffs(
+        changes=[{
+            "changeType": "edit",
+            "item": {
+                "isFolder": False,
+                "path": "foo.py",
+            },
+        }],
+    )
+    diff = Diff(blocks=[Block(
+        changeType=1,
+        mLines=["    bar = foo.new_method()"],
+        mLine=5,
+        mLinesCount=1,
+    )])
+    mock_diff_response = mock.MagicMock()
+    mock_diff_response.json.return_value = diff
+    mock_requests_get.return_value = mock_diff_response
+
+    pr_id = 123
+    pr = GitPullRequest(
+        created_by=IdentityRef(display_name="P.R. Author"),
+        is_draft=False,
+        pull_request_id=pr_id,
+        repository=GitRepository(),
+        reviewers=[
+            IdentityRefWithVote(id=runner.config["user_id"], vote=WAIT),
+        ],
+        status="active",
+    )
+    pr_url = f"https://example.com/pr/{pr_id}"
+
+    runner.review_pr(pr, pr_url, run_state=None)
+
+    runner.git_client.create_pull_request_reviewer.assert_called_once()
+    call_args = runner.git_client.create_pull_request_reviewer.call_args
+    assert call_args.args[0].id == runner.config["user_id"]
+    assert call_args.args[0].vote == NO_VOTE
+    assert call_args.args[2] == pr_id
+    assert call_args.kwargs.get("reviewer_id") == runner.config["user_id"]
 
 
 def test_review_pr_vote_based_on_description():
@@ -63,7 +134,7 @@ def test_review_pr_vote_based_on_description():
 
     runner.review_pr(pr, pr_url, run_state=None)
 
-    assert runner.git_client.create_pull_request_reviewer.assert_called_once()
+    runner.git_client.create_pull_request_reviewer.assert_called_once()
     call_args = runner.git_client.create_pull_request_reviewer.call_args
     assert call_args.args[0].id == runner.config["user_id"]
     assert call_args.args[0].vote == NO_VOTE

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,71 @@
+from datetime import datetime
+import os
+from unittest import mock
+
+from azure.devops.released.git import (
+    Comment,
+    GitPullRequest,
+    GitPullRequestCommentThread,
+    GitPullRequestIteration,
+    GitRepository,
+    IdentityRef,
+    IdentityRefWithVote,
+)
+from injector import Injector
+
+from config.config_module import ConfigModule
+from logger import LoggingModule
+from run import Runner
+from voting import NO_VOTE, WAIT
+
+
+TESTS_DIR = os.path.dirname(__file__)
+
+
+def test_review_pr_vote_based_on_description():
+    """
+    This tests the scenario where there's a rule that votes based on the PR description and the vote has already been
+    applied to the PR and the PR description was updated and now the vote needs to be reset.
+    """
+    config_path = os.path.join(TESTS_DIR, "configs/vote_based_on_description.yml")
+    inj = Injector([
+        ConfigModule(config_path),
+        LoggingModule,
+    ])
+    runner = inj.get(Runner)
+    reload_info = runner.config_loader.load_config()
+    runner.config = reload_info.config
+    runner.git_client = mock.MagicMock()
+    runner.git_client.get_threads.return_value = [
+        GitPullRequestCommentThread(
+            comments=[Comment(author=IdentityRef(id=runner.config["user_id"]))],
+            last_updated_date=datetime(2024, 12, 19),
+            properties={"CodeReviewVoteResult": {"$value": WAIT}},
+        ),
+    ]
+    runner.git_client.get_pull_request_iterations.return_value = [
+        GitPullRequestIteration(updated_date=datetime(2024, 12, 18)),
+    ]
+
+    pr_id = 123
+    pr = GitPullRequest(
+        created_by=IdentityRef(display_name="P.R. Author"),
+        description="This is a good description.",
+        is_draft=False,
+        pull_request_id=pr_id,
+        repository=GitRepository(),
+        reviewers=[
+            IdentityRefWithVote(id=runner.config["user_id"], vote=WAIT),
+        ],
+        status="active",
+    )
+    pr_url = f"https://example.com/pr/{pr_id}"
+
+    runner.review_pr(pr, pr_url, run_state=None)
+
+    assert runner.git_client.create_pull_request_reviewer.assert_called_once()
+    call_args = runner.git_client.create_pull_request_reviewer.call_args
+    assert call_args.args[0].id == runner.config["user_id"]
+    assert call_args.args[0].vote == NO_VOTE
+    assert call_args.args[2] == pr_id
+    assert call_args.kwargs.get("reviewer_id") == runner.config["user_id"]

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -662,9 +662,10 @@ def test_review_pr_both_reset_votes_options_reset_after_changes(mock_requests_ge
     mock_diff_response.json.return_value = diff
     mock_requests_get.return_value = mock_diff_response
 
+    call_arg_votes = []
+
     # Use a side_effect to collect the votes in the call args for create_pull_request_reviewer because we reuse the
     # same reviewer object that is passed to the first call and we change the vote value later.
-    call_arg_votes = []
     def mock_create_pull_request_reviewer(*args, **kwargs):
         call_arg_votes.append(args[0].vote)
     runner.git_client.create_pull_request_reviewer.side_effect = mock_create_pull_request_reviewer

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -19,7 +19,7 @@ from config.config_module import ConfigModule
 from file_diff import Block, Diff
 from logger import LoggingModule
 from run import Runner
-from voting import NO_VOTE, WAIT
+from voting import APPROVE_VOTE, NO_VOTE, WAIT
 
 
 TESTS_DIR = os.path.dirname(__file__)
@@ -91,6 +91,74 @@ def test_review_pr_vote_based_on_diff_pattern_reset(mock_requests_get):
     assert call_args.args[0].vote == NO_VOTE
     assert call_args.args[2] == pr_id
     assert call_args.kwargs.get("reviewer_id") == runner.config["user_id"]
+
+
+@mock.patch.object(requests, "get")
+def test_review_pr_vote_based_on_diff_pattern_no_reset(mock_requests_get):
+    """
+    This tests the scenario where there's a rule that votes based on a diff pattern and the vote has already been
+    applied to the PR and a new iteration was pushed, but another vote was cast manually, so it should not be reset.
+    """
+    config_path = os.path.join(TESTS_DIR, "configs/vote_based_on_diff_pattern.yml")
+    inj = Injector([
+        ConfigModule(config_path),
+        LoggingModule,
+    ])
+    runner = inj.get(Runner)
+    reload_info = runner.config_loader.load_config()
+    runner.config = reload_info.config
+    runner.git_client = mock.MagicMock()
+    runner.git_client.get_threads.return_value = [
+        GitPullRequestCommentThread(
+            comments=[Comment(author=IdentityRef(id=runner.config["user_id"]))],
+            last_updated_date=datetime(2024, 12, 19),
+            properties={"CodeReviewVoteResult": {"$value": WAIT}},
+        ),
+        GitPullRequestCommentThread(
+            comments=[Comment(author=IdentityRef(id=runner.config["user_id"]))],
+            last_updated_date=datetime(2024, 12, 21),
+            properties={"CodeReviewVoteResult": {"$value": APPROVE_VOTE}},
+        ),
+    ]
+    runner.git_client.get_pull_request_iterations.return_value = [
+        GitPullRequestIteration(updated_date=datetime(2024, 12, 18)),
+        GitPullRequestIteration(updated_date=datetime(2024, 12, 20)),
+    ]
+    runner.git_client.get_commit_diffs.return_value = GitCommitDiffs(
+        changes=[{
+            "changeType": "edit",
+            "item": {
+                "isFolder": False,
+                "path": "foo.py",
+            },
+        }],
+    )
+    diff = Diff(blocks=[Block(
+        changeType=1,
+        mLines=["    bar = foo.new_method()"],
+        mLine=5,
+        mLinesCount=1,
+    )])
+    mock_diff_response = mock.MagicMock()
+    mock_diff_response.json.return_value = diff
+    mock_requests_get.return_value = mock_diff_response
+
+    pr_id = 123
+    pr = GitPullRequest(
+        created_by=IdentityRef(display_name="P.R. Author"),
+        is_draft=False,
+        pull_request_id=pr_id,
+        repository=GitRepository(),
+        reviewers=[
+            IdentityRefWithVote(id=runner.config["user_id"], vote=APPROVE_VOTE),
+        ],
+        status="active",
+    )
+    pr_url = f"https://example.com/pr/{pr_id}"
+
+    runner.review_pr(pr, pr_url, run_state=None)
+
+    runner.git_client.create_pull_request_reviewer.assert_not_called()
 
 
 def test_review_pr_vote_based_on_description():

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -19,7 +19,7 @@ from config.config_module import ConfigModule
 from file_diff import Block, Diff
 from logger import LoggingModule
 from run import Runner
-from voting import APPROVE_VOTE, NO_VOTE, WAIT
+from voting import APPROVE_VOTE, NO_VOTE, WAIT_VOTE
 
 
 TESTS_DIR = os.path.dirname(__file__)
@@ -44,7 +44,7 @@ def test_review_pr_vote_based_on_diff_pattern_reset(mock_requests_get):
         GitPullRequestCommentThread(
             comments=[Comment(author=IdentityRef(id=runner.config["user_id"]))],
             last_updated_date=datetime(2024, 12, 19),
-            properties={"CodeReviewVoteResult": {"$value": WAIT}},
+            properties={"CodeReviewVoteResult": {"$value": WAIT_VOTE}},
         ),
     ]
     runner.git_client.get_pull_request_iterations.return_value = [
@@ -77,7 +77,7 @@ def test_review_pr_vote_based_on_diff_pattern_reset(mock_requests_get):
         pull_request_id=pr_id,
         repository=GitRepository(),
         reviewers=[
-            IdentityRefWithVote(id=runner.config["user_id"], vote=WAIT),
+            IdentityRefWithVote(id=runner.config["user_id"], vote=WAIT_VOTE),
         ],
         status="active",
     )
@@ -112,7 +112,7 @@ def test_review_pr_vote_based_on_diff_pattern_no_reset(mock_requests_get):
         GitPullRequestCommentThread(
             comments=[Comment(author=IdentityRef(id=runner.config["user_id"]))],
             last_updated_date=datetime(2024, 12, 19),
-            properties={"CodeReviewVoteResult": {"$value": WAIT}},
+            properties={"CodeReviewVoteResult": {"$value": WAIT_VOTE}},
         ),
         GitPullRequestCommentThread(
             comments=[Comment(author=IdentityRef(id=runner.config["user_id"]))],
@@ -179,7 +179,7 @@ def test_review_pr_vote_based_on_description():
         GitPullRequestCommentThread(
             comments=[Comment(author=IdentityRef(id=runner.config["user_id"]))],
             last_updated_date=datetime(2024, 12, 19),
-            properties={"CodeReviewVoteResult": {"$value": WAIT}},
+            properties={"CodeReviewVoteResult": {"$value": WAIT_VOTE}},
         ),
     ]
     runner.git_client.get_pull_request_iterations.return_value = [
@@ -194,7 +194,7 @@ def test_review_pr_vote_based_on_description():
         pull_request_id=pr_id,
         repository=GitRepository(),
         reviewers=[
-            IdentityRefWithVote(id=runner.config["user_id"], vote=WAIT),
+            IdentityRefWithVote(id=runner.config["user_id"], vote=WAIT_VOTE),
         ],
         status="active",
     )


### PR DESCRIPTION
This is a possible solution to #51.

Add an option to reset certain votes if none of the rules vote. This is especially useful when running the Code Reviewer as an independent bot with its own user account (rather than running it on behalf of a human user).  It allows resetting the vote in cases where an issue that was detected by a rule has been corrected without changing the code, for example by changing the PR description. Previously, the Code Reviewer would not automatically reset its vote when such a rule no longer applied. The new option allows to configure the Code Reviewer to reset its vote in such cases.

I added test cases not just for the new functionality, but also for various scenarios discussed in #51 to demonstrate that those scenarios work.